### PR TITLE
Remove explicit variable declaration from Concourse deployment

### DIFF
--- a/concourse/concourse.yml
+++ b/concourse/concourse.yml
@@ -73,10 +73,6 @@ instance_groups:
         listen_network: tcp
         listen_address: 0.0.0.0:7777
 
-variables:
-- name: postgresql-concourse-password
-  type: password
-
 update:
   canaries: 1
   max_in_flight: 1


### PR DESCRIPTION
This is now causing BOSH to complain that it isn't set up with a config
server, even though the variable value is provided on the command line.