### PR TITLE
Revert "Remove explicit variable declaration from Concourse deployment"

### DIFF
--- a/concourse/concourse.yml
+++ b/concourse/concourse.yml
@@ -73,6 +73,10 @@ instance_groups:
         listen_network: tcp
         listen_address: 0.0.0.0:7777
 
+variables:
+- name: postgresql-concourse-password
+  type: password
+
 update:
   canaries: 1
   max_in_flight: 1


### PR DESCRIPTION
This change was made to unblock deployment of Logsearch, but more work
needs to be done with Concourse.

This reverts commit e545e6b913a1f82636ddf997e859aeec21f98527.