### PR TITLE
Use the latest stemcell release version

### DIFF
--- a/concourse/concourse.yml
+++ b/concourse/concourse.yml
@@ -14,7 +14,7 @@ releases:
 stemcells:
 - alias: default
   os: ubuntu-trusty
-  version: "3445.latest"
+  version: latest
 
 instance_groups:
 - name: web


### PR DESCRIPTION
Specifying the version is problematic because the deployment can fail if
the BOSH director doesn't have the right version.  The reason for
specifying the version was to avoid having the deployment chase the
bleeding edge, but we can manage the available versions in the BOSH
director.  If a specific stemcell version turns out to break a
deployment (as caught in testing) we can always temporarily pin the
version in the deployment.