### PR TITLE
Add encryption_key

### DIFF
--- a/concourse/concourse.yml
+++ b/concourse/concourse.yml
@@ -31,6 +31,7 @@ instance_groups:
   - name: atc
     release: concourse
     properties:
+      encryption_key: ((encryption-key))
       external_url: http://localhost/
 
       token_signing_key: ((token_signing_key))
@@ -102,6 +103,10 @@ variables:
   type: ssh
 - name: worker_key
   type: ssh
+- name: encryption-key
+  type: password
+  options:
+    length: 32
 
 update:
   canaries: 1


### PR DESCRIPTION
Concourse supports an [encryption_key property](https://concourse.ci/encryption.html#section_enabling-encryption), so we may as well just always use it in the base manifest. I have tested that this change can be safely applied to an existing deployment of concourse.