### PR TITLE
Use cloudfoundry postgres BOSH release

### DIFF
--- a/concourse/concourse.yml
+++ b/concourse/concourse.yml
@@ -10,6 +10,10 @@ releases:
   version: "1.9.0"
   url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.9.0
   sha1: 77bfe8bdb2c3daec5b40f5116a6216badabd196c
+- name: postgres
+  version: "22"
+  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=22
+  sha1: 86a1333122e9cdd051551c83ec26d36f6e325d6c
 
 stemcells:
 - alias: default
@@ -32,7 +36,12 @@ instance_groups:
       basic_auth_username: REPLACE_ME
       basic_auth_password: REPLACE_ME
 
-      postgresql_database: &atc_db atc
+      postgresql:
+        database: atc
+        role:
+          name: concoursedb
+          password: ((postgresql-concourse-password))
+
   - name: tsa
     release: concourse
     properties: {}
@@ -45,13 +54,16 @@ instance_groups:
   azs: [z1]
   networks: [{name: default}]
   jobs:
-  - name: postgresql
-    release: concourse
+  - name: postgres
+    release: postgres
     properties:
       databases:
-      - name: *atc_db
-        role: concoursedb
-        password: ((postgresql-concourse-password))
+        port: 5432
+        databases:
+        - name: atc
+        roles:
+        - name: concoursedb
+          password: ((postgresql-concourse-password))
 
 - name: worker
   instances: 1

--- a/concourse/operators/shield.yml
+++ b/concourse/operators/shield.yml
@@ -18,7 +18,7 @@
             pg_user: vcap
             pg_password: local-access-via-vcap-user
             pg_database:  atc
-            pg_bindir:  /var/vcap/packages/postgres-unknown/bin/
+            pg_bindir:  /var/vcap/packages/postgres-9.6.4/bin/
       jobs:
         concourse:
           retention: default


### PR DESCRIPTION
The previous included postgresql job is deprecated
https://concourse.ci/downloads.html#v350

I have not been able to get automatic data migration between the old postgres release to the new, so I will be manually backing up and restoring (or more specifically I will use SHIELD)