### PR TITLE
Update to Concourse v3.8.0

### DIFF
--- a/concourse/concourse.yml
+++ b/concourse/concourse.yml
@@ -3,9 +3,9 @@ name: concourse
 
 releases:
 - name: concourse
-  version: "3.7.0"
-  url: https://bosh.io/d/github.com/concourse/concourse?v=3.7.0
-  sha1: 20e17e3ac079f1b1a5095329a4fb14de40317bb9
+  version: "3.8.0"
+  url: https://bosh.io/d/github.com/concourse/concourse?v=3.8.0
+  sha1: 99e134676df72e18c719ccfbd7977bd9449e6fd4
 - name: garden-runc
   version: "1.9.0"
   url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.9.0


### PR DESCRIPTION
New version of Concourse. Looks like v3.7.0 was pretty shortlived:
<https://concourse.ci/downloads.html#v380>