### PR TITLE
Set default and maximum build log retention

### DIFF
--- a/concourse/concourse.yml
+++ b/concourse/concourse.yml
@@ -46,6 +46,10 @@ instance_groups:
           name: concoursedb
           password: ((postgresql-concourse-password))
 
+      build_log_retention:
+        default: 1000
+        maximum: 10000
+
   - name: tsa
     release: concourse
     properties:


### PR DESCRIPTION
Jobs can override this up to the max